### PR TITLE
Update Debian Version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-buster
+ARG PYTHON_VERSION=3.12-slim-bookworm
 
 FROM python:${PYTHON_VERSION}
 


### PR DESCRIPTION
This Dockerfile does not work for me on a fresh install because it looks like the buster tag no longer exists and was replaced with bookworm.