### PR TITLE
Update dependencies

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -734,8 +734,8 @@ dependencies = [
     { name = "blurhash" },
     { name = "decorator" },
     { name = "python-dateutil" },
-    { name = "python-magic", marker = "platform_system != 'Windows'" },
-    { name = "python-magic-bin", marker = "platform_system == 'Windows'" },
+    { name = "python-magic", marker = "sys_platform != 'win32'" },
+    { name = "python-magic-bin", marker = "sys_platform == 'win32'" },
     { name = "requests" },
     { name = "six" },
 ]
@@ -779,20 +779,21 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.14.0"
+version = "1.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/7b/08046ef9330735f536a09a2e31b00f42bccdb2795dcd979636ba43bb2d63/mypy-1.14.0.tar.gz", hash = "sha256:822dbd184d4a9804df5a7d5335a68cf7662930e70b8c1bc976645d1509f9a9d6", size = 3215684 }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/eb/2c92d8ea1e684440f54fa49ac5d9a5f19967b7b472a281f419e69a8d228e/mypy-1.14.1.tar.gz", hash = "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6", size = 3216051 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/33/8380efd0ebdfdfac7fc0bf065f03a049800ca1e6c296ec1afc634340d992/mypy-1.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9f6f4c0b27401d14c483c622bc5105eff3911634d576bbdf6695b9a7c1ba741", size = 11251509 },
-    { url = "https://files.pythonhosted.org/packages/15/6d/4e1c21c60fee11af7d8e4f2902a29886d1387d6a836be16229eb3982a963/mypy-1.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b2280cedcb312c7a79f5001ae5325582d0d339bce684e4a529069d0e7ca1e7", size = 10244282 },
-    { url = "https://files.pythonhosted.org/packages/8b/cf/7a8ae5c0161edae15d25c2c67c68ce8b150cbdc45aefc13a8be271ee80b2/mypy-1.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:342de51c48bab326bfc77ce056ba08c076d82ce4f5a86621f972ed39970f94d8", size = 12867676 },
-    { url = "https://files.pythonhosted.org/packages/9c/d0/71f7bbdcc7cfd0f2892db5b13b1e8857673f2cc9e0c30e3e4340523dc186/mypy-1.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00df23b42e533e02a6f0055e54de9a6ed491cd8b7ea738647364fd3a39ea7efc", size = 12964189 },
-    { url = "https://files.pythonhosted.org/packages/a7/40/fb4ad65d6d5f8c51396ecf6305ec0269b66013a5bf02d0e9528053640b4a/mypy-1.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:e8c8387e5d9dff80e7daf961df357c80e694e942d9755f3ad77d69b0957b8e3f", size = 9888247 },
-    { url = "https://files.pythonhosted.org/packages/39/32/0214608af400cdf8f5102144bb8af10d880675c65ed0b58f7e0e77175d50/mypy-1.14.0-py3-none-any.whl", hash = "sha256:2238d7f93fc4027ed1efc944507683df3ba406445a2b6c96e79666a045aadfab", size = 2752803 },
+    { url = "https://files.pythonhosted.org/packages/9e/15/bb6a686901f59222275ab228453de741185f9d54fecbaacec041679496c6/mypy-1.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:92c3ed5afb06c3a8e188cb5da4984cab9ec9a77ba956ee419c68a388b4595255", size = 11252097 },
+    { url = "https://files.pythonhosted.org/packages/f8/b3/8b0f74dfd072c802b7fa368829defdf3ee1566ba74c32a2cb2403f68024c/mypy-1.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dbec574648b3e25f43d23577309b16534431db4ddc09fda50841f1e34e64ed34", size = 10239728 },
+    { url = "https://files.pythonhosted.org/packages/c5/9b/4fd95ab20c52bb5b8c03cc49169be5905d931de17edfe4d9d2986800b52e/mypy-1.14.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c6d94b16d62eb3e947281aa7347d78236688e21081f11de976376cf010eb31a", size = 11924965 },
+    { url = "https://files.pythonhosted.org/packages/56/9d/4a236b9c57f5d8f08ed346914b3f091a62dd7e19336b2b2a0d85485f82ff/mypy-1.14.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4b19b03fdf54f3c5b2fa474c56b4c13c9dbfb9a2db4370ede7ec11a2c5927d9", size = 12867660 },
+    { url = "https://files.pythonhosted.org/packages/40/88/a61a5497e2f68d9027de2bb139c7bb9abaeb1be1584649fa9d807f80a338/mypy-1.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0c911fde686394753fff899c409fd4e16e9b294c24bfd5e1ea4675deae1ac6fd", size = 12969198 },
+    { url = "https://files.pythonhosted.org/packages/54/da/3d6fc5d92d324701b0c23fb413c853892bfe0e1dbe06c9138037d459756b/mypy-1.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:8b21525cb51671219f5307be85f7e646a153e5acc656e5cebf64bfa076c50107", size = 9885276 },
+    { url = "https://files.pythonhosted.org/packages/a0/b5/32dd67b69a16d088e533962e5044e51004176a9952419de0370cdaead0f8/mypy-1.14.1-py3-none-any.whl", hash = "sha256:b66a60cc4073aeb8ae00057f9c1f64d49e90f918fbcef9a977eb121da8b8f1d1", size = 2752905 },
 ]
 
 [[package]]
@@ -1279,7 +1280,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [


### PR DESCRIPTION
Using CPython 3.13.1
Creating virtual environment at: .venv
Resolved 105 packages in 623ms
Prepared 100 packages in 1.93s
Installed 100 packages in 197ms
 + annotated-types==0.7.0
 + anyio==4.7.0
 + asgiref==3.8.1
 + blurhash==1.1.4
 + certifi==2024.12.14
 + cfgv==3.4.0
 + charset-normalizer==3.4.1
 + click==8.1.8
 + colorama==0.4.6
 + coverage==7.6.10
 + cssbeautifier==1.15.1
 + decorator==5.1.1
 + distlib==0.3.9
 + distro==1.9.0
 + django==5.1.4
 + django-browser-reload==1.17.0
 + django-cotton==1.5.1
 + django-coverage-plugin==3.1.0
 + django-csp==4.0b2
 + django-debug-toolbar==4.4.6
 + django-dramatiq==0.12.0
 + django-environ==0.11.2
 + django-rich==1.13.0
 + django-tailwind==3.8.0
 + django-template-partials==24.4
 + django-tui==24.5
 + django-watchfiles==1.0.0
 + django-zeal==2.0.2
 + djlint==1.36.4
 + dramatiq==1.17.1
 + editorconfig==0.17.0
 + filelock==3.16.1
 + flakytest==2023.0b11
 + gevent==24.11.1
 + greenlet==3.1.1
 + gunicorn==23.0.0
 + h11==0.14.0
 + heroicons==2.9.0
 + httpcore==1.0.7
 + httpx==0.28.1
 + identify==2.6.4
 + idna==3.10
 + iniconfig==2.0.0
 + jiter==0.8.2
 + jsbeautifier==1.15.1
 + json5==0.10.0
 + linkify-it-py==2.0.3
 + markdown-it-py==3.0.0
 + mastodon-py==1.8.1
 + mdit-py-plugins==0.4.2
 + mdurl==0.1.2
 + model-bakery==1.20.0
 + mypy==1.14.1
 + mypy-extensions==1.0.0
 + nodeenv==1.9.1
 + openai==1.58.1
 + packaging==24.2
 + pathspec==0.12.1
 + platformdirs==4.3.6
 + pluggy==1.5.0
 + pre-commit==4.0.1
 + prometheus-client==0.21.1
 + psycopg==3.2.3
 + psycopg-binary==3.2.3
 + psycopg-pool==3.2.4
 + pydantic==2.10.4
 + pydantic-core==2.27.2
 + pygments==2.18.0
 + pytest==8.3.4
 + pytest-cov==6.0.0
 + pytest-django==4.9.0
 + python-dateutil==2.9.0.post0
 + python-dotenv==1.0.1
 + python-magic==0.4.27
 + pyyaml==6.0.2
 + redis==5.2.1
 + regex==2024.11.6
 + requests==2.32.3
 + rich==13.9.4
 + ruff==0.8.4
 + schedule==1.2.2
 + sentry-sdk==2.19.2
 + setproctitle==1.3.4
 + setuptools==75.6.0
 + six==1.17.0
 + sniffio==1.3.1
 + sqlparse==0.5.3
 + textual==1.0.0
 + tqdm==4.67.1
 + trogon==0.6.0
 + typing-extensions==4.12.2
 + uc-micro-py==1.0.3
 + urllib3==2.3.0
 + virtualenv==20.28.0
 + watchdog==6.0.0
 + watchdog-gevent==0.2.1
 + watchfiles==1.0.3
 + whitenoise==6.8.2
 + zope-event==5.0
 + zope-interface==7.2
