### PR TITLE
Add context to the "Following" string

### DIFF
--- a/accounts/templates/cotton/follow_button.html
+++ b/accounts/templates/cotton/follow_button.html
@@ -8,7 +8,7 @@
 {% elif account.is_following %}
     <button disable
             class="absolute -bottom-12 end-2 cursor-not-allowed rounded-lg bg-gray-300 px-4 py-2 text-sm font-medium text-gray-900 opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
-        {% trans "Following" %}
+        {% trans "Following" context "You are already *following* this account." %}
     </button>
 {% elif user.accountaccess.account.account_id == account.account_id %}
     <button disable

--- a/accounts/templates/v2/accounts.html
+++ b/accounts/templates/v2/accounts.html
@@ -109,7 +109,7 @@
                         </span>
                     </div>
                     <div class="flex flex-col gap-0 text-center" title="Following">
-                        <span class="text-xs">{% trans "Following" %}</span>
+                        <span class="text-xs">{% trans "Following" context "This account is *following* this many people" %}</span>
                         <span class="font-semibold text-gray-700 truncate dark:text-gray-400 text-md">
                             {% if sort_order == '-accountlookup__daily_following_count' %}
                                 <span class="{% if account.accountlookup.daily_following_count > 0 %}text-green-600{% endif %}">▼ {{ account.accountlookup.daily_following_count | intcomma }}</span>

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-01 15:45+0000\n"
+"POT-Creation-Date: 2025-01-02 14:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,35 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-#: accounts/models.py:190
-msgid "Never posted"
-msgstr ""
-
-#: accounts/models.py:193
-msgid "Less than a day ago"
-msgstr ""
-
-#: accounts/models.py:197
-#, python-format
-msgid "%(days)d day ago"
-msgid_plural "%(days)d days ago"
-msgstr[0] ""
-msgstr[1] ""
-
-#: accounts/models.py:204
-#, python-format
-msgid "%(weeks)d week ago"
-msgid_plural "%(weeks)d weeks ago"
-msgstr[0] ""
-msgstr[1] ""
-
-#: accounts/models.py:210
-#, python-format
-msgid "%(months)d month ago"
-msgid_plural "%(months)d months ago"
-msgstr[0] ""
-msgstr[1] ""
 
 #: accounts/templates/cotton/follow_button.html:6
 #: accounts/templates/cotton/follow_button.html:23
@@ -99,6 +70,7 @@ msgid "Followers"
 msgstr ""
 
 #: accounts/templates/v2/accounts.html:112
+#: starter_packs/templates/starter_pack_accounts.html:112
 msgctxt "This account is *following* this many people"
 msgid "Following"
 msgstr ""
@@ -220,7 +192,6 @@ msgid "Account has moved"
 msgstr ""
 
 #: starter_packs/templates/add_accounts.html:7
-#: starter_packs/templates/review_starter_pack.html:7
 msgid "Add accounts to"
 msgstr ""
 
@@ -234,7 +205,6 @@ msgid "Search @username@instance.org"
 msgstr ""
 
 #: starter_packs/templates/add_accounts_list.html:20
-#: starter_packs/templates/review_starter_pack_list.html:20
 #, python-format
 msgid ""
 "⚠️ The account is not set as <a href=\"%(url)s\">discoverable</a> and cannot "
@@ -332,10 +302,6 @@ msgstr ""
 msgid "Yes, delete"
 msgstr ""
 
-#: starter_packs/templates/review_starter_pack_list.html:40
-msgid "No accounts in this starter pack"
-msgstr ""
-
 #: starter_packs/templates/share_starter_pack.html:20
 #: starter_packs/templates/share_starter_pack.html:32
 #, python-format
@@ -379,10 +345,6 @@ msgstr ""
 msgid "Switch to Human"
 msgstr ""
 
-#: starter_packs/templates/starter_pack_accounts.html:112
-msgid "Following"
-msgstr ""
-
 #: starter_packs/templates/starter_pack_stats.html:6
 #, python-format
 msgid "%(counter)s account in your starter pack."
@@ -390,14 +352,9 @@ msgid_plural "%(counter)s accounts in your starter pack."
 msgstr[0] ""
 msgstr[1] ""
 
-#: starter_packs/templates/starter_pack_stats.html:17
-#: starter_packs/templates/starter_pack_stats.html:21
+#: starter_packs/templates/starter_pack_stats.html:16
+#: starter_packs/templates/starter_pack_stats.html:20
 msgid "Finish"
-msgstr ""
-
-#: starter_packs/templates/starter_pack_stats.html:26
-#: starter_packs/templates/starter_pack_stats.html:30
-msgid "Review"
 msgstr ""
 
 #: starter_packs/templates/starter_packs.html:11
@@ -431,8 +388,8 @@ msgstr ""
 
 #: starter_packs/templates/starter_packs.html:107
 msgid ""
-"Please login to see your starter packs or search for your "
-"username@instance.org in the search form above"
+"Please login to see your starter packs or search for your username@instance."
+"org in the search form above"
 msgstr ""
 
 #: starter_packs/templates/starter_packs.html:112
@@ -456,36 +413,30 @@ msgstr ""
 msgid "Mastodon Starter Pack Directory | Fedidevs"
 msgstr ""
 
-#: starter_packs/views.py:142 starter_packs/views.py:210
+#: starter_packs/views.py:162
 msgid "Add accounts to your starter pack"
 msgstr ""
 
-#: starter_packs/views.py:144
-msgid ""
-"Add accounts to your starter pack to help new users find interesting "
-"accounts to follow."
-msgstr ""
-
-#: starter_packs/views.py:243
+#: starter_packs/views.py:195
 msgid "Edit your starter pack"
 msgstr ""
 
-#: starter_packs/views.py:269
+#: starter_packs/views.py:221
 msgid "You already have a starter pack with this title."
 msgstr ""
 
-#: starter_packs/views.py:279
+#: starter_packs/views.py:231
 msgid "Create a new starter pack"
 msgstr ""
 
-#: starter_packs/views.py:306
+#: starter_packs/views.py:258
 msgid "You have reached the maximum number of accounts in a starter pack."
 msgstr ""
 
-#: starter_packs/views.py:351
+#: starter_packs/views.py:303
 msgid " - Mastodon Starter Pack"
 msgstr ""
 
-#: starter_packs/views.py:399
+#: starter_packs/views.py:351
 msgid "Following all accounts in the starter pack. 🎉"
 msgstr ""

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-01 15:45+0000\n"
+"POT-Creation-Date: 2025-01-02 14:15+0000\n"
 "PO-Revision-Date: 2025-01-01 15:54+0000\n"
 "Last-Translator: Juanjo Salvador <juanjosalvador@netc.eu>\n"
 "Language-Team: \n"
@@ -18,38 +18,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
 "1 : 2;\n"
 "X-Generator: Poedit 3.5\n"
-
-#: accounts/models.py:190
-msgid "Never posted"
-msgstr "Nunca publicado"
-
-#: accounts/models.py:193
-msgid "Less than a day ago"
-msgstr ""
-
-#: accounts/models.py:197
-#, python-format
-msgid "%(days)d day ago"
-msgid_plural "%(days)d days ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: accounts/models.py:204
-#, python-format
-msgid "%(weeks)d week ago"
-msgid_plural "%(weeks)d weeks ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: accounts/models.py:210
-#, python-format
-msgid "%(months)d month ago"
-msgid_plural "%(months)d months ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
 
 #: accounts/templates/cotton/follow_button.html:6
 #: accounts/templates/cotton/follow_button.html:23
@@ -105,6 +73,7 @@ msgid "Followers"
 msgstr "Seguidores"
 
 #: accounts/templates/v2/accounts.html:112
+#: starter_packs/templates/starter_pack_accounts.html:112
 msgctxt "This account is *following* this many people"
 msgid "Following"
 msgstr "Siguiendo"
@@ -230,7 +199,6 @@ msgid "Account has moved"
 msgstr "La cuenta se ha trasladado"
 
 #: starter_packs/templates/add_accounts.html:7
-#: starter_packs/templates/review_starter_pack.html:7
 msgid "Add accounts to"
 msgstr "Añadir cuentas a"
 
@@ -244,7 +212,6 @@ msgid "Search @username@instance.org"
 msgstr "Buscar @usuario@instancia.org"
 
 #: starter_packs/templates/add_accounts_list.html:20
-#: starter_packs/templates/review_starter_pack_list.html:20
 #, python-format
 msgid ""
 "⚠️ The account is not set as <a href=\"%(url)s\">discoverable</a> and cannot "
@@ -360,10 +327,6 @@ msgstr "Seguro que quieres eliminar este pack de inicio"
 msgid "Yes, delete"
 msgstr "Sí, eliminar"
 
-#: starter_packs/templates/review_starter_pack_list.html:40
-msgid "No accounts in this starter pack"
-msgstr "No hay cuentas en este pack de inicio"
-
 #: starter_packs/templates/share_starter_pack.html:20
 #: starter_packs/templates/share_starter_pack.html:32
 #, python-format
@@ -415,10 +378,6 @@ msgstr "Cambiar a Projecto"
 msgid "Switch to Human"
 msgstr "Cambiar a Humano"
 
-#: starter_packs/templates/starter_pack_accounts.html:112
-msgid "Following"
-msgstr "Siguiendo"
-
 #: starter_packs/templates/starter_pack_stats.html:6
 #, python-format
 msgid "%(counter)s account in your starter pack."
@@ -427,15 +386,10 @@ msgstr[0] "%(counter)s cuenta en tu pack de inicio."
 msgstr[1] "%(counter)s cuenta en tu pack de inicio."
 msgstr[2] "%(counter)s cuentas en tu pack de inicio."
 
-#: starter_packs/templates/starter_pack_stats.html:17
-#: starter_packs/templates/starter_pack_stats.html:21
+#: starter_packs/templates/starter_pack_stats.html:16
+#: starter_packs/templates/starter_pack_stats.html:20
 msgid "Finish"
 msgstr "Terminar"
-
-#: starter_packs/templates/starter_pack_stats.html:26
-#: starter_packs/templates/starter_pack_stats.html:30
-msgid "Review"
-msgstr "Revisar"
 
 #: starter_packs/templates/starter_packs.html:11
 msgid "Community Starter Packs"
@@ -495,38 +449,49 @@ msgstr "Crea tu pack de inicio"
 msgid "Mastodon Starter Pack Directory | Fedidevs"
 msgstr "Directorio de Packs de Inicio de Mastodon | Fedidevs"
 
-#: starter_packs/views.py:142 starter_packs/views.py:210
+#: starter_packs/views.py:162
 msgid "Add accounts to your starter pack"
 msgstr "Añade cuentas a tu pack de inicio"
 
-#: starter_packs/views.py:144
-msgid ""
-"Add accounts to your starter pack to help new users find interesting "
-"accounts to follow."
-msgstr ""
-"Añade cuentas a tu pack de inicio para ayudar a nuevos usuarios a encontrar "
-"cuentas interesantes para seguir."
-
-#: starter_packs/views.py:243
+#: starter_packs/views.py:195
 msgid "Edit your starter pack"
 msgstr "Editar tu pack de inicio"
 
-#: starter_packs/views.py:269
+#: starter_packs/views.py:221
 msgid "You already have a starter pack with this title."
 msgstr "Ya has creado un pack de inicio con este título."
 
-#: starter_packs/views.py:279
+#: starter_packs/views.py:231
 msgid "Create a new starter pack"
 msgstr "Crear un nuevo pack de inicio"
 
-#: starter_packs/views.py:306
+#: starter_packs/views.py:258
 msgid "You have reached the maximum number of accounts in a starter pack."
 msgstr "Has alcanzado el máximo número de cuentas en un pack de inicio."
 
-#: starter_packs/views.py:351
+#: starter_packs/views.py:303
 msgid " - Mastodon Starter Pack"
 msgstr " - Pack de Inicio de Mastodon"
 
-#: starter_packs/views.py:399
+#: starter_packs/views.py:351
 msgid "Following all accounts in the starter pack. 🎉"
 msgstr "Siguiendo todas las cuentas del pack de inicio. 🎉"
+
+#~ msgid "Never posted"
+#~ msgstr "Nunca publicado"
+
+#~ msgid "No accounts in this starter pack"
+#~ msgstr "No hay cuentas en este pack de inicio"
+
+#~ msgid "Following"
+#~ msgstr "Siguiendo"
+
+#~ msgid "Review"
+#~ msgstr "Revisar"
+
+#~ msgid ""
+#~ "Add accounts to your starter pack to help new users find interesting "
+#~ "accounts to follow."
+#~ msgstr ""
+#~ "Añade cuentas a tu pack de inicio para ayudar a nuevos usuarios a "
+#~ "encontrar cuentas interesantes para seguir."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -25,7 +25,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Fedidevs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-01 15:45+0000\n"
+"POT-Creation-Date: 2025-01-02 14:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Benjamin Sonntag <benjamin@octopuce.fr>\n"
 "Language-Team: \n"
@@ -34,37 +34,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-
-#: accounts/models.py:190
-#, fuzzy
-#| msgid "Last posted"
-msgid "Never posted"
-msgstr "Dernier post"
-
-#: accounts/models.py:193
-msgid "Less than a day ago"
-msgstr ""
-
-#: accounts/models.py:197
-#, python-format
-msgid "%(days)d day ago"
-msgid_plural "%(days)d days ago"
-msgstr[0] ""
-msgstr[1] ""
-
-#: accounts/models.py:204
-#, python-format
-msgid "%(weeks)d week ago"
-msgid_plural "%(weeks)d weeks ago"
-msgstr[0] ""
-msgstr[1] ""
-
-#: accounts/models.py:210
-#, python-format
-msgid "%(months)d month ago"
-msgid_plural "%(months)d months ago"
-msgstr[0] ""
-msgstr[1] ""
 
 #: accounts/templates/cotton/follow_button.html:6
 #: accounts/templates/cotton/follow_button.html:23
@@ -122,6 +91,7 @@ msgid "Followers"
 msgstr "Abonné·e·s"
 
 #: accounts/templates/v2/accounts.html:112
+#: starter_packs/templates/starter_pack_accounts.html:112
 #, fuzzy
 #| msgid "Following"
 msgctxt "This account is *following* this many people"
@@ -249,7 +219,6 @@ msgid "Account has moved"
 msgstr "Le compte a migré"
 
 #: starter_packs/templates/add_accounts.html:7
-#: starter_packs/templates/review_starter_pack.html:7
 msgid "Add accounts to"
 msgstr "Ajouter des comptes à"
 
@@ -263,7 +232,6 @@ msgid "Search @username@instance.org"
 msgstr "Rechercher @utilisateur@instance.org"
 
 #: starter_packs/templates/add_accounts_list.html:20
-#: starter_packs/templates/review_starter_pack_list.html:20
 #, python-format
 msgid ""
 "⚠️ The account is not set as <a href=\"%(url)s\">discoverable</a> and cannot "
@@ -319,9 +287,8 @@ msgid ""
 "<strong>Tip:</strong> Try searching for <strong>@username@instance.org</"
 "strong> to find the user directly on their instance."
 msgstr ""
-"<strong>Astuce :</strong> Essayez de chercher "
-"<strong>@utilisateur@instance.org</strong> pour trouver l'utilisateur "
-"directement sur son instance."
+"<strong>Astuce :</strong> Essayez de chercher <strong>@utilisateur@instance."
+"org</strong> pour trouver l'utilisateur directement sur son instance."
 
 #: starter_packs/templates/add_accounts_list.html:81
 msgid ""
@@ -380,10 +347,6 @@ msgstr "Êtes-vous sûr de vouloir effacer ce Pack à suivre"
 msgid "Yes, delete"
 msgstr "Oui, effacer"
 
-#: starter_packs/templates/review_starter_pack_list.html:40
-msgid "No accounts in this starter pack"
-msgstr ""
-
 #: starter_packs/templates/share_starter_pack.html:20
 #: starter_packs/templates/share_starter_pack.html:32
 #, python-format
@@ -431,10 +394,6 @@ msgstr "Marquer comme Projet"
 msgid "Switch to Human"
 msgstr "Marquer comme Humain"
 
-#: starter_packs/templates/starter_pack_accounts.html:112
-msgid "Following"
-msgstr "Suivi"
-
 #: starter_packs/templates/starter_pack_stats.html:6
 #, python-format
 msgid "%(counter)s account in your starter pack."
@@ -442,15 +401,10 @@ msgid_plural "%(counter)s accounts in your starter pack."
 msgstr[0] "%(counter)s compte dans votre Pack à suivre."
 msgstr[1] "%(counter)s comptes dans votre Pack à suivre."
 
-#: starter_packs/templates/starter_pack_stats.html:17
-#: starter_packs/templates/starter_pack_stats.html:21
+#: starter_packs/templates/starter_pack_stats.html:16
+#: starter_packs/templates/starter_pack_stats.html:20
 msgid "Finish"
 msgstr "Terminer"
-
-#: starter_packs/templates/starter_pack_stats.html:26
-#: starter_packs/templates/starter_pack_stats.html:30
-msgid "Review"
-msgstr ""
 
 #: starter_packs/templates/starter_packs.html:11
 msgid "Community Starter Packs"
@@ -483,8 +437,8 @@ msgstr "Connectez-vous pour voir vos Packs à suivre."
 
 #: starter_packs/templates/starter_packs.html:107
 msgid ""
-"Please login to see your starter packs or search for your "
-"username@instance.org in the search form above"
+"Please login to see your starter packs or search for your username@instance."
+"org in the search form above"
 msgstr ""
 "Connectez-vous pour voir vos Packs à suivre ou chercher des "
 "utilisateurs@instance.org dans le formulaire ci-dessus"
@@ -510,37 +464,39 @@ msgstr "Créez votre Pack à suivre"
 msgid "Mastodon Starter Pack Directory | Fedidevs"
 msgstr "Répertoire des Packs à suivre Mastodon | Fedidevs"
 
-#: starter_packs/views.py:142 starter_packs/views.py:210
+#: starter_packs/views.py:162
 msgid "Add accounts to your starter pack"
 msgstr "Ajouter des comptes à votre Pack à suivre"
 
-#: starter_packs/views.py:144
-msgid ""
-"Add accounts to your starter pack to help new users find interesting "
-"accounts to follow."
-msgstr ""
-
-#: starter_packs/views.py:243
+#: starter_packs/views.py:195
 msgid "Edit your starter pack"
 msgstr "Modifier votre Pack à suivre"
 
-#: starter_packs/views.py:269
+#: starter_packs/views.py:221
 msgid "You already have a starter pack with this title."
 msgstr "Vous avez déjà un Pack à suivre avec ce nom."
 
-#: starter_packs/views.py:279
+#: starter_packs/views.py:231
 msgid "Create a new starter pack"
 msgstr "Créer un noueau Pack à suivre"
 
-#: starter_packs/views.py:306
+#: starter_packs/views.py:258
 msgid "You have reached the maximum number of accounts in a starter pack."
 msgstr ""
 "Vous avez atteint le nombre maximum de comptes dans votre Pack à suivre."
 
-#: starter_packs/views.py:351
+#: starter_packs/views.py:303
 msgid " - Mastodon Starter Pack"
 msgstr " - Pack à suivre Mastodon"
 
-#: starter_packs/views.py:399
+#: starter_packs/views.py:351
 msgid "Following all accounts in the starter pack. 🎉"
 msgstr "Suivre tous les comptes dans ce Pack à suivre. 🎉"
+
+#, fuzzy
+#~| msgid "Last posted"
+#~ msgid "Never posted"
+#~ msgstr "Dernier post"
+
+#~ msgid "Following"
+#~ msgstr "Suivi"

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Fedidevs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-01 15:45+0000\n"
+"POT-Creation-Date: 2025-01-02 14:15+0000\n"
 "PO-Revision-Date: 2024-12-30 17:11+0100\n"
 "Last-Translator: Enrico Bonardi <e.bonardi@me.com>\n"
 "Language-Team: \n"
@@ -25,37 +25,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.5\n"
-
-#: accounts/models.py:190
-#, fuzzy
-#| msgid "Last posted"
-msgid "Never posted"
-msgstr "Ultimo messaggio"
-
-#: accounts/models.py:193
-msgid "Less than a day ago"
-msgstr ""
-
-#: accounts/models.py:197
-#, python-format
-msgid "%(days)d day ago"
-msgid_plural "%(days)d days ago"
-msgstr[0] ""
-msgstr[1] ""
-
-#: accounts/models.py:204
-#, python-format
-msgid "%(weeks)d week ago"
-msgid_plural "%(weeks)d weeks ago"
-msgstr[0] ""
-msgstr[1] ""
-
-#: accounts/models.py:210
-#, python-format
-msgid "%(months)d month ago"
-msgid_plural "%(months)d months ago"
-msgstr[0] ""
-msgstr[1] ""
 
 #: accounts/templates/cotton/follow_button.html:6
 #: accounts/templates/cotton/follow_button.html:23
@@ -111,6 +80,7 @@ msgid "Followers"
 msgstr "Follower"
 
 #: accounts/templates/v2/accounts.html:112
+#: starter_packs/templates/starter_pack_accounts.html:112
 msgctxt "This account is *following* this many people"
 msgid "Following"
 msgstr "Seguici"
@@ -236,7 +206,6 @@ msgid "Account has moved"
 msgstr "L'account è stato spostato"
 
 #: starter_packs/templates/add_accounts.html:7
-#: starter_packs/templates/review_starter_pack.html:7
 msgid "Add accounts to"
 msgstr "Aggiungi account a"
 
@@ -250,7 +219,6 @@ msgid "Search @username@instance.org"
 msgstr "Cerca @username@instance.org"
 
 #: starter_packs/templates/add_accounts_list.html:20
-#: starter_packs/templates/review_starter_pack_list.html:20
 #, python-format
 msgid ""
 "⚠️ The account is not set as <a href=\"%(url)s\">discoverable</a> and cannot "
@@ -305,9 +273,8 @@ msgid ""
 "<strong>Tip:</strong> Try searching for <strong>@username@instance.org</"
 "strong> to find the user directly on their instance."
 msgstr ""
-"<strong>Consiglio:</strong> Prova ad utilizzare "
-"<strong>@username@instance.org</strong> per trovare l'utente direttamente "
-"nella sua istanza."
+"<strong>Consiglio:</strong> Prova ad utilizzare <strong>@username@instance."
+"org</strong> per trovare l'utente direttamente nella sua istanza."
 
 #: starter_packs/templates/add_accounts_list.html:81
 msgid ""
@@ -366,10 +333,6 @@ msgstr "Sei sicuro di voler eliminare il tuo starter pack"
 msgid "Yes, delete"
 msgstr "Si, elimina"
 
-#: starter_packs/templates/review_starter_pack_list.html:40
-msgid "No accounts in this starter pack"
-msgstr "Nessun account in questo starter pack"
-
 #: starter_packs/templates/share_starter_pack.html:20
 #: starter_packs/templates/share_starter_pack.html:32
 #, python-format
@@ -417,10 +380,6 @@ msgstr "Passa a Progetto"
 msgid "Switch to Human"
 msgstr "Passa a Umano"
 
-#: starter_packs/templates/starter_pack_accounts.html:112
-msgid "Following"
-msgstr "Seguici"
-
 #: starter_packs/templates/starter_pack_stats.html:6
 #, python-format
 msgid "%(counter)s account in your starter pack."
@@ -428,15 +387,10 @@ msgid_plural "%(counter)s accounts in your starter pack."
 msgstr[0] "%(counter)s account nel tuo starter pack."
 msgstr[1] "%(counter)s account nel tuo starter pack."
 
-#: starter_packs/templates/starter_pack_stats.html:17
-#: starter_packs/templates/starter_pack_stats.html:21
+#: starter_packs/templates/starter_pack_stats.html:16
+#: starter_packs/templates/starter_pack_stats.html:20
 msgid "Finish"
 msgstr "Termina"
-
-#: starter_packs/templates/starter_pack_stats.html:26
-#: starter_packs/templates/starter_pack_stats.html:30
-msgid "Review"
-msgstr "Rivedi"
 
 #: starter_packs/templates/starter_packs.html:11
 msgid "Community Starter Packs"
@@ -469,8 +423,8 @@ msgstr "Per favore esegui il login per vedere i tuoi starter pack."
 
 #: starter_packs/templates/starter_packs.html:107
 msgid ""
-"Please login to see your starter packs or search for your "
-"username@instance.org in the search form above"
+"Please login to see your starter packs or search for your username@instance."
+"org in the search form above"
 msgstr ""
 "Per favore esegui il login per vedere i tuoi starter pack oppure cercare il "
 "tuo username@instance.org nel form di ricerca qua sopra"
@@ -496,38 +450,51 @@ msgstr "Crea il tuo starter pack"
 msgid "Mastodon Starter Pack Directory | Fedidevs"
 msgstr "Elenco degli starter pack di Mastodon | Fedidevs"
 
-#: starter_packs/views.py:142 starter_packs/views.py:210
+#: starter_packs/views.py:162
 msgid "Add accounts to your starter pack"
 msgstr "Aggiungi account al tuo starter pack"
 
-#: starter_packs/views.py:144
-msgid ""
-"Add accounts to your starter pack to help new users find interesting "
-"accounts to follow."
-msgstr ""
-"Aggiungi account al tuo starter pack per aiutare i nuovi utenti a trovare "
-"account interessanti da seguire."
-
-#: starter_packs/views.py:243
+#: starter_packs/views.py:195
 msgid "Edit your starter pack"
 msgstr "Modifica il tuo starter pack"
 
-#: starter_packs/views.py:269
+#: starter_packs/views.py:221
 msgid "You already have a starter pack with this title."
 msgstr "Hai già uno starter pack con questo titolo."
 
-#: starter_packs/views.py:279
+#: starter_packs/views.py:231
 msgid "Create a new starter pack"
 msgstr "Crea un nuovo starter pack"
 
-#: starter_packs/views.py:306
+#: starter_packs/views.py:258
 msgid "You have reached the maximum number of accounts in a starter pack."
 msgstr "Hai raggiunto il numero massimo di account in uno starter pack."
 
-#: starter_packs/views.py:351
+#: starter_packs/views.py:303
 msgid " - Mastodon Starter Pack"
 msgstr " - Starter Pack di Mastodon"
 
-#: starter_packs/views.py:399
+#: starter_packs/views.py:351
 msgid "Following all accounts in the starter pack. 🎉"
 msgstr "Stai seguendo tutti gli account di questo starter pack. 🎉"
+
+#, fuzzy
+#~| msgid "Last posted"
+#~ msgid "Never posted"
+#~ msgstr "Ultimo messaggio"
+
+#~ msgid "No accounts in this starter pack"
+#~ msgstr "Nessun account in questo starter pack"
+
+#~ msgid "Following"
+#~ msgstr "Seguici"
+
+#~ msgid "Review"
+#~ msgstr "Rivedi"
+
+#~ msgid ""
+#~ "Add accounts to your starter pack to help new users find interesting "
+#~ "accounts to follow."
+#~ msgstr ""
+#~ "Aggiungi account al tuo starter pack per aiutare i nuovi utenti a trovare "
+#~ "account interessanti da seguire."

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-01 15:45+0000\n"
+"POT-Creation-Date: 2025-01-02 14:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,35 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-#: accounts/models.py:190
-msgid "Never posted"
-msgstr ""
-
-#: accounts/models.py:193
-msgid "Less than a day ago"
-msgstr ""
-
-#: accounts/models.py:197
-#, python-format
-msgid "%(days)d day ago"
-msgid_plural "%(days)d days ago"
-msgstr[0] ""
-msgstr[1] ""
-
-#: accounts/models.py:204
-#, python-format
-msgid "%(weeks)d week ago"
-msgid_plural "%(weeks)d weeks ago"
-msgstr[0] ""
-msgstr[1] ""
-
-#: accounts/models.py:210
-#, python-format
-msgid "%(months)d month ago"
-msgid_plural "%(months)d months ago"
-msgstr[0] ""
-msgstr[1] ""
 
 #: accounts/templates/cotton/follow_button.html:6
 #: accounts/templates/cotton/follow_button.html:23
@@ -99,6 +70,7 @@ msgid "Followers"
 msgstr ""
 
 #: accounts/templates/v2/accounts.html:112
+#: starter_packs/templates/starter_pack_accounts.html:112
 msgctxt "This account is *following* this many people"
 msgid "Following"
 msgstr ""
@@ -220,7 +192,6 @@ msgid "Account has moved"
 msgstr ""
 
 #: starter_packs/templates/add_accounts.html:7
-#: starter_packs/templates/review_starter_pack.html:7
 msgid "Add accounts to"
 msgstr ""
 
@@ -234,7 +205,6 @@ msgid "Search @username@instance.org"
 msgstr ""
 
 #: starter_packs/templates/add_accounts_list.html:20
-#: starter_packs/templates/review_starter_pack_list.html:20
 #, python-format
 msgid ""
 "⚠️ The account is not set as <a href=\"%(url)s\">discoverable</a> and cannot "
@@ -332,10 +302,6 @@ msgstr ""
 msgid "Yes, delete"
 msgstr ""
 
-#: starter_packs/templates/review_starter_pack_list.html:40
-msgid "No accounts in this starter pack"
-msgstr ""
-
 #: starter_packs/templates/share_starter_pack.html:20
 #: starter_packs/templates/share_starter_pack.html:32
 #, python-format
@@ -379,10 +345,6 @@ msgstr ""
 msgid "Switch to Human"
 msgstr ""
 
-#: starter_packs/templates/starter_pack_accounts.html:112
-msgid "Following"
-msgstr ""
-
 #: starter_packs/templates/starter_pack_stats.html:6
 #, python-format
 msgid "%(counter)s account in your starter pack."
@@ -390,14 +352,9 @@ msgid_plural "%(counter)s accounts in your starter pack."
 msgstr[0] ""
 msgstr[1] ""
 
-#: starter_packs/templates/starter_pack_stats.html:17
-#: starter_packs/templates/starter_pack_stats.html:21
+#: starter_packs/templates/starter_pack_stats.html:16
+#: starter_packs/templates/starter_pack_stats.html:20
 msgid "Finish"
-msgstr ""
-
-#: starter_packs/templates/starter_pack_stats.html:26
-#: starter_packs/templates/starter_pack_stats.html:30
-msgid "Review"
 msgstr ""
 
 #: starter_packs/templates/starter_packs.html:11
@@ -431,8 +388,8 @@ msgstr ""
 
 #: starter_packs/templates/starter_packs.html:107
 msgid ""
-"Please login to see your starter packs or search for your "
-"username@instance.org in the search form above"
+"Please login to see your starter packs or search for your username@instance."
+"org in the search form above"
 msgstr ""
 
 #: starter_packs/templates/starter_packs.html:112
@@ -456,36 +413,30 @@ msgstr ""
 msgid "Mastodon Starter Pack Directory | Fedidevs"
 msgstr ""
 
-#: starter_packs/views.py:142 starter_packs/views.py:210
+#: starter_packs/views.py:162
 msgid "Add accounts to your starter pack"
 msgstr ""
 
-#: starter_packs/views.py:144
-msgid ""
-"Add accounts to your starter pack to help new users find interesting "
-"accounts to follow."
-msgstr ""
-
-#: starter_packs/views.py:243
+#: starter_packs/views.py:195
 msgid "Edit your starter pack"
 msgstr ""
 
-#: starter_packs/views.py:269
+#: starter_packs/views.py:221
 msgid "You already have a starter pack with this title."
 msgstr ""
 
-#: starter_packs/views.py:279
+#: starter_packs/views.py:231
 msgid "Create a new starter pack"
 msgstr ""
 
-#: starter_packs/views.py:306
+#: starter_packs/views.py:258
 msgid "You have reached the maximum number of accounts in a starter pack."
 msgstr ""
 
-#: starter_packs/views.py:351
+#: starter_packs/views.py:303
 msgid " - Mastodon Starter Pack"
 msgstr ""
 
-#: starter_packs/views.py:399
+#: starter_packs/views.py:351
 msgid "Following all accounts in the starter pack. 🎉"
 msgstr ""

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-01 15:45+0000\n"
+"POT-Creation-Date: 2025-01-02 14:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,41 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
 "(n%100>=11 && n%100<=14)? 2 : 3);\n"
-
-#: accounts/models.py:190
-msgid "Never posted"
-msgstr ""
-
-#: accounts/models.py:193
-msgid "Less than a day ago"
-msgstr ""
-
-#: accounts/models.py:197
-#, python-format
-msgid "%(days)d day ago"
-msgid_plural "%(days)d days ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-
-#: accounts/models.py:204
-#, python-format
-msgid "%(weeks)d week ago"
-msgid_plural "%(weeks)d weeks ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-
-#: accounts/models.py:210
-#, python-format
-msgid "%(months)d month ago"
-msgid_plural "%(months)d months ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
 
 #: accounts/templates/cotton/follow_button.html:6
 #: accounts/templates/cotton/follow_button.html:23
@@ -107,6 +72,7 @@ msgid "Followers"
 msgstr ""
 
 #: accounts/templates/v2/accounts.html:112
+#: starter_packs/templates/starter_pack_accounts.html:112
 msgctxt "This account is *following* this many people"
 msgid "Following"
 msgstr ""
@@ -228,7 +194,6 @@ msgid "Account has moved"
 msgstr ""
 
 #: starter_packs/templates/add_accounts.html:7
-#: starter_packs/templates/review_starter_pack.html:7
 msgid "Add accounts to"
 msgstr ""
 
@@ -242,7 +207,6 @@ msgid "Search @username@instance.org"
 msgstr ""
 
 #: starter_packs/templates/add_accounts_list.html:20
-#: starter_packs/templates/review_starter_pack_list.html:20
 #, python-format
 msgid ""
 "⚠️ The account is not set as <a href=\"%(url)s\">discoverable</a> and cannot "
@@ -340,10 +304,6 @@ msgstr ""
 msgid "Yes, delete"
 msgstr ""
 
-#: starter_packs/templates/review_starter_pack_list.html:40
-msgid "No accounts in this starter pack"
-msgstr ""
-
 #: starter_packs/templates/share_starter_pack.html:20
 #: starter_packs/templates/share_starter_pack.html:32
 #, python-format
@@ -387,10 +347,6 @@ msgstr ""
 msgid "Switch to Human"
 msgstr ""
 
-#: starter_packs/templates/starter_pack_accounts.html:112
-msgid "Following"
-msgstr ""
-
 #: starter_packs/templates/starter_pack_stats.html:6
 #, python-format
 msgid "%(counter)s account in your starter pack."
@@ -398,14 +354,9 @@ msgid_plural "%(counter)s accounts in your starter pack."
 msgstr[0] ""
 msgstr[1] ""
 
-#: starter_packs/templates/starter_pack_stats.html:17
-#: starter_packs/templates/starter_pack_stats.html:21
+#: starter_packs/templates/starter_pack_stats.html:16
+#: starter_packs/templates/starter_pack_stats.html:20
 msgid "Finish"
-msgstr ""
-
-#: starter_packs/templates/starter_pack_stats.html:26
-#: starter_packs/templates/starter_pack_stats.html:30
-msgid "Review"
 msgstr ""
 
 #: starter_packs/templates/starter_packs.html:11
@@ -439,8 +390,8 @@ msgstr ""
 
 #: starter_packs/templates/starter_packs.html:107
 msgid ""
-"Please login to see your starter packs or search for your "
-"username@instance.org in the search form above"
+"Please login to see your starter packs or search for your username@instance."
+"org in the search form above"
 msgstr ""
 
 #: starter_packs/templates/starter_packs.html:112
@@ -464,36 +415,30 @@ msgstr ""
 msgid "Mastodon Starter Pack Directory | Fedidevs"
 msgstr ""
 
-#: starter_packs/views.py:142 starter_packs/views.py:210
+#: starter_packs/views.py:162
 msgid "Add accounts to your starter pack"
 msgstr ""
 
-#: starter_packs/views.py:144
-msgid ""
-"Add accounts to your starter pack to help new users find interesting "
-"accounts to follow."
-msgstr ""
-
-#: starter_packs/views.py:243
+#: starter_packs/views.py:195
 msgid "Edit your starter pack"
 msgstr ""
 
-#: starter_packs/views.py:269
+#: starter_packs/views.py:221
 msgid "You already have a starter pack with this title."
 msgstr ""
 
-#: starter_packs/views.py:279
+#: starter_packs/views.py:231
 msgid "Create a new starter pack"
 msgstr ""
 
-#: starter_packs/views.py:306
+#: starter_packs/views.py:258
 msgid "You have reached the maximum number of accounts in a starter pack."
 msgstr ""
 
-#: starter_packs/views.py:351
+#: starter_packs/views.py:303
 msgid " - Mastodon Starter Pack"
 msgstr ""
 
-#: starter_packs/views.py:399
+#: starter_packs/views.py:351
 msgid "Following all accounts in the starter pack. 🎉"
 msgstr ""

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Fedidevs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-01 15:45+0000\n"
+"POT-Creation-Date: 2025-01-02 14:15+0000\n"
 "PO-Revision-Date: 2025-01-01 15:52+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,41 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100>=3 && "
 "n%100<=4 ? 2 : 3);\n"
 "X-Generator: Poedit 3.5\n"
-
-#: accounts/models.py:190
-msgid "Never posted"
-msgstr "Nazadnje objevljeno"
-
-#: accounts/models.py:193
-msgid "Less than a day ago"
-msgstr "Pred manj kot enim dnevom"
-
-#: accounts/models.py:197
-#, python-format
-msgid "%(days)d day ago"
-msgid_plural "%(days)d days ago"
-msgstr[0] "Pred %(days)d dnevom"
-msgstr[1] "Pred %(days)d dnevoma"
-msgstr[2] "Pred %(days)d dnevi"
-msgstr[3] "Pred %(days)d dnevi"
-
-#: accounts/models.py:204
-#, python-format
-msgid "%(weeks)d week ago"
-msgid_plural "%(weeks)d weeks ago"
-msgstr[0] "Pred %(weeks)d tednom"
-msgstr[1] "Pred %(weeks)d tednoma"
-msgstr[2] "Pred %(weeks)d tedni"
-msgstr[3] "Pred %(weeks)d tedni"
-
-#: accounts/models.py:210
-#, python-format
-msgid "%(months)d month ago"
-msgid_plural "%(months)d months ago"
-msgstr[0] "Pred %(months)d mesecem"
-msgstr[1] "Pred %(months)d meseci"
-msgstr[2] "Pred %(months)d meseci"
-msgstr[3] "Pred %(months)d meseci"
 
 #: accounts/templates/cotton/follow_button.html:6
 #: accounts/templates/cotton/follow_button.html:23
@@ -109,6 +74,7 @@ msgid "Followers"
 msgstr "Sledilci"
 
 #: accounts/templates/v2/accounts.html:112
+#: starter_packs/templates/starter_pack_accounts.html:112
 msgctxt "This account is *following* this many people"
 msgid "Following"
 msgstr "Sledi"
@@ -235,7 +201,6 @@ msgid "Account has moved"
 msgstr "Račun je bil premaknjen"
 
 #: starter_packs/templates/add_accounts.html:7
-#: starter_packs/templates/review_starter_pack.html:7
 msgid "Add accounts to"
 msgstr "Dodaj račune v"
 
@@ -249,7 +214,6 @@ msgid "Search @username@instance.org"
 msgstr "Išči @username@instance.org"
 
 #: starter_packs/templates/add_accounts_list.html:20
-#: starter_packs/templates/review_starter_pack_list.html:20
 #, python-format
 msgid ""
 "⚠️ The account is not set as <a href=\"%(url)s\">discoverable</a> and cannot "
@@ -364,10 +328,6 @@ msgstr "Ali ste prepričani, da želite zbrisati začetni paket"
 msgid "Yes, delete"
 msgstr "Ja, zbriši"
 
-#: starter_packs/templates/review_starter_pack_list.html:40
-msgid "No accounts in this starter pack"
-msgstr "V začetnem paketu ni računov"
-
 #: starter_packs/templates/share_starter_pack.html:20
 #: starter_packs/templates/share_starter_pack.html:32
 #, python-format
@@ -423,10 +383,6 @@ msgstr "Preklopi na projekt"
 msgid "Switch to Human"
 msgstr "Preklopi na človeka"
 
-#: starter_packs/templates/starter_pack_accounts.html:112
-msgid "Following"
-msgstr "Slediš"
-
 #: starter_packs/templates/starter_pack_stats.html:6
 #, python-format
 msgid "%(counter)s account in your starter pack."
@@ -436,15 +392,10 @@ msgstr[1] "%(counter)s računa v vašem začetnem paketu."
 msgstr[2] "%(counter)s računi v vašem začetnem paketu."
 msgstr[3] "%(counter)s računov v vašem začetnem paketu."
 
-#: starter_packs/templates/starter_pack_stats.html:17
-#: starter_packs/templates/starter_pack_stats.html:21
+#: starter_packs/templates/starter_pack_stats.html:16
+#: starter_packs/templates/starter_pack_stats.html:20
 msgid "Finish"
 msgstr "Končaj"
-
-#: starter_packs/templates/starter_pack_stats.html:26
-#: starter_packs/templates/starter_pack_stats.html:30
-msgid "Review"
-msgstr "Preglej"
 
 #: starter_packs/templates/starter_packs.html:11
 msgid "Community Starter Packs"
@@ -505,38 +456,76 @@ msgstr "Ustvarite svoj začetni paket"
 msgid "Mastodon Starter Pack Directory | Fedidevs"
 msgstr "Imenik začetnih paketov Mastodon | Fedidevs"
 
-#: starter_packs/views.py:142 starter_packs/views.py:210
+#: starter_packs/views.py:162
 msgid "Add accounts to your starter pack"
 msgstr "Dodajte račune v svoj začetni paket"
 
-#: starter_packs/views.py:144
-msgid ""
-"Add accounts to your starter pack to help new users find interesting "
-"accounts to follow."
-msgstr ""
-"Dodajte račune v svoj začetni paket, da boste novim uporabnikom pomagali "
-"najti zanimive račune, ki jim bodo sledili."
-
-#: starter_packs/views.py:243
+#: starter_packs/views.py:195
 msgid "Edit your starter pack"
 msgstr "Uredite svoj začetni paket"
 
-#: starter_packs/views.py:269
+#: starter_packs/views.py:221
 msgid "You already have a starter pack with this title."
 msgstr "Že imate začetni paket s tem naslovom."
 
-#: starter_packs/views.py:279
+#: starter_packs/views.py:231
 msgid "Create a new starter pack"
 msgstr "Ustvarite nov začetni paket"
 
-#: starter_packs/views.py:306
+#: starter_packs/views.py:258
 msgid "You have reached the maximum number of accounts in a starter pack."
 msgstr "Dosegli ste največje število računov v začetnem paketu."
 
-#: starter_packs/views.py:351
+#: starter_packs/views.py:303
 msgid " - Mastodon Starter Pack"
 msgstr " - Začetni paket Mastodon"
 
-#: starter_packs/views.py:399
+#: starter_packs/views.py:351
 msgid "Following all accounts in the starter pack. 🎉"
 msgstr "Spremljanje vseh računov v začetnem paketu. 🎉"
+
+#~ msgid "Never posted"
+#~ msgstr "Nazadnje objevljeno"
+
+#~ msgid "Less than a day ago"
+#~ msgstr "Pred manj kot enim dnevom"
+
+#, python-format
+#~ msgid "%(days)d day ago"
+#~ msgid_plural "%(days)d days ago"
+#~ msgstr[0] "Pred %(days)d dnevom"
+#~ msgstr[1] "Pred %(days)d dnevoma"
+#~ msgstr[2] "Pred %(days)d dnevi"
+#~ msgstr[3] "Pred %(days)d dnevi"
+
+#, python-format
+#~ msgid "%(weeks)d week ago"
+#~ msgid_plural "%(weeks)d weeks ago"
+#~ msgstr[0] "Pred %(weeks)d tednom"
+#~ msgstr[1] "Pred %(weeks)d tednoma"
+#~ msgstr[2] "Pred %(weeks)d tedni"
+#~ msgstr[3] "Pred %(weeks)d tedni"
+
+#, python-format
+#~ msgid "%(months)d month ago"
+#~ msgid_plural "%(months)d months ago"
+#~ msgstr[0] "Pred %(months)d mesecem"
+#~ msgstr[1] "Pred %(months)d meseci"
+#~ msgstr[2] "Pred %(months)d meseci"
+#~ msgstr[3] "Pred %(months)d meseci"
+
+#~ msgid "No accounts in this starter pack"
+#~ msgstr "V začetnem paketu ni računov"
+
+#~ msgid "Following"
+#~ msgstr "Slediš"
+
+#~ msgid "Review"
+#~ msgstr "Preglej"
+
+#~ msgid ""
+#~ "Add accounts to your starter pack to help new users find interesting "
+#~ "accounts to follow."
+#~ msgstr ""
+#~ "Dodajte račune v svoj začetni paket, da boste novim uporabnikom pomagali "
+#~ "najti zanimive račune, ki jim bodo sledili."

--- a/locale/sp/LC_MESSAGES/django.po
+++ b/locale/sp/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-01 15:45+0000\n"
+"POT-Creation-Date: 2025-01-02 14:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,35 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-
-#: accounts/models.py:190
-msgid "Never posted"
-msgstr ""
-
-#: accounts/models.py:193
-msgid "Less than a day ago"
-msgstr ""
-
-#: accounts/models.py:197
-#, python-format
-msgid "%(days)d day ago"
-msgid_plural "%(days)d days ago"
-msgstr[0] ""
-msgstr[1] ""
-
-#: accounts/models.py:204
-#, python-format
-msgid "%(weeks)d week ago"
-msgid_plural "%(weeks)d weeks ago"
-msgstr[0] ""
-msgstr[1] ""
-
-#: accounts/models.py:210
-#, python-format
-msgid "%(months)d month ago"
-msgid_plural "%(months)d months ago"
-msgstr[0] ""
-msgstr[1] ""
 
 #: accounts/templates/cotton/follow_button.html:6
 #: accounts/templates/cotton/follow_button.html:23
@@ -99,6 +70,7 @@ msgid "Followers"
 msgstr ""
 
 #: accounts/templates/v2/accounts.html:112
+#: starter_packs/templates/starter_pack_accounts.html:112
 msgctxt "This account is *following* this many people"
 msgid "Following"
 msgstr ""
@@ -220,7 +192,6 @@ msgid "Account has moved"
 msgstr ""
 
 #: starter_packs/templates/add_accounts.html:7
-#: starter_packs/templates/review_starter_pack.html:7
 msgid "Add accounts to"
 msgstr ""
 
@@ -234,7 +205,6 @@ msgid "Search @username@instance.org"
 msgstr ""
 
 #: starter_packs/templates/add_accounts_list.html:20
-#: starter_packs/templates/review_starter_pack_list.html:20
 #, python-format
 msgid ""
 "⚠️ The account is not set as <a href=\"%(url)s\">discoverable</a> and cannot "
@@ -332,10 +302,6 @@ msgstr ""
 msgid "Yes, delete"
 msgstr ""
 
-#: starter_packs/templates/review_starter_pack_list.html:40
-msgid "No accounts in this starter pack"
-msgstr ""
-
 #: starter_packs/templates/share_starter_pack.html:20
 #: starter_packs/templates/share_starter_pack.html:32
 #, python-format
@@ -379,10 +345,6 @@ msgstr ""
 msgid "Switch to Human"
 msgstr ""
 
-#: starter_packs/templates/starter_pack_accounts.html:112
-msgid "Following"
-msgstr ""
-
 #: starter_packs/templates/starter_pack_stats.html:6
 #, python-format
 msgid "%(counter)s account in your starter pack."
@@ -390,14 +352,9 @@ msgid_plural "%(counter)s accounts in your starter pack."
 msgstr[0] ""
 msgstr[1] ""
 
-#: starter_packs/templates/starter_pack_stats.html:17
-#: starter_packs/templates/starter_pack_stats.html:21
+#: starter_packs/templates/starter_pack_stats.html:16
+#: starter_packs/templates/starter_pack_stats.html:20
 msgid "Finish"
-msgstr ""
-
-#: starter_packs/templates/starter_pack_stats.html:26
-#: starter_packs/templates/starter_pack_stats.html:30
-msgid "Review"
 msgstr ""
 
 #: starter_packs/templates/starter_packs.html:11
@@ -431,8 +388,8 @@ msgstr ""
 
 #: starter_packs/templates/starter_packs.html:107
 msgid ""
-"Please login to see your starter packs or search for your "
-"username@instance.org in the search form above"
+"Please login to see your starter packs or search for your username@instance."
+"org in the search form above"
 msgstr ""
 
 #: starter_packs/templates/starter_packs.html:112
@@ -456,36 +413,30 @@ msgstr ""
 msgid "Mastodon Starter Pack Directory | Fedidevs"
 msgstr ""
 
-#: starter_packs/views.py:142 starter_packs/views.py:210
+#: starter_packs/views.py:162
 msgid "Add accounts to your starter pack"
 msgstr ""
 
-#: starter_packs/views.py:144
-msgid ""
-"Add accounts to your starter pack to help new users find interesting "
-"accounts to follow."
-msgstr ""
-
-#: starter_packs/views.py:243
+#: starter_packs/views.py:195
 msgid "Edit your starter pack"
 msgstr ""
 
-#: starter_packs/views.py:269
+#: starter_packs/views.py:221
 msgid "You already have a starter pack with this title."
 msgstr ""
 
-#: starter_packs/views.py:279
+#: starter_packs/views.py:231
 msgid "Create a new starter pack"
 msgstr ""
 
-#: starter_packs/views.py:306
+#: starter_packs/views.py:258
 msgid "You have reached the maximum number of accounts in a starter pack."
 msgstr ""
 
-#: starter_packs/views.py:351
+#: starter_packs/views.py:303
 msgid " - Mastodon Starter Pack"
 msgstr ""
 
-#: starter_packs/views.py:399
+#: starter_packs/views.py:351
 msgid "Following all accounts in the starter pack. 🎉"
 msgstr ""

--- a/starter_packs/templates/starter_pack_accounts.html
+++ b/starter_packs/templates/starter_pack_accounts.html
@@ -109,7 +109,7 @@
                         </span>
                     </div>
                     <div class="flex flex-col gap-0 text-center" title="Following">
-                        <span class="text-xs">{% trans "Following" %}</span>
+                        <span class="text-xs">{% trans "Following" context "This account is *following* this many people" %}</span>
                         <span class="font-semibold text-gray-700 truncate dark:text-gray-400 text-md">
                             {% if sort_order == '-accountlookup__daily_following_count' %}
                                 <span class="{% if account.accountlookup.daily_following_count > 0 %}text-green-600{% endif %}">▼ {{ account.accountlookup.daily_following_count | intcomma }}</span>


### PR DESCRIPTION
This PR adds context for the "Following" string directly to the templates, so that it remains in place when doing `makemessages`. This PR also runs `makemessages`, which causes other strings to update, too.

See [Fedi post](https://fosstodon.org/@kytta/113741772863582408) for context (no pun intended)