### PR TITLE
Add host-meta support to WebFinger lookup

### DIFF
--- a/accounts/management/commands/crawlone.py
+++ b/accounts/management/commands/crawlone.py
@@ -65,7 +65,7 @@ async def crawlone(user: str, make_visible: bool = False):
             "statuses_count": account["statuses_count"],
             "note": account["note"],
             "url": account["url"],
-            "activitypub_id": account["uri"],
+            "activitypub_id": account.get("uri"),
             "avatar": account["avatar"],
             "avatar_static": account["avatar_static"],
             "header": account["header"],

--- a/accounts/management/commands/webfinger.py
+++ b/accounts/management/commands/webfinger.py
@@ -2,6 +2,7 @@ import logging
 from json import JSONDecodeError
 
 import httpx
+import xml.etree.ElementTree
 from asgiref.sync import async_to_sync
 from django_rich.management import RichCommand
 
@@ -10,11 +11,34 @@ from accounts.models import Account
 logger = logging.getLogger(__name__)
 
 
-async def get_activitypub_id_from_webfinger(acct, instance, client: httpx.AsyncClient):
+async def get_activitypub_id_from_webfinger(acct, instance, client: httpx.AsyncClient, host_meta_cache):
+    if instance not in host_meta_cache:
+        try:
+            response = await client.get(
+                f"https://{instance}/.well-known/host-meta",
+                follow_redirects=True, # Should not be required, but who knows
+                timeout=30,
+            )
+        except httpx.HTTPError:
+            # Many servers do not implement host-meta and rely on WebFinger's default URL.
+            # This is not a failure state.
+            pass
+        if response is not None and response.status_code == 200:
+            try:
+                host_meta = xml.etree.ElementTree.fromstring(response.text)
+            except xml.etree.ElementTree.ParseError:
+                logger.info("%s Error: decoding host-meta XML", acct)
+            for element in host_meta or []:
+                if element.attrib.get("rel") == "lrdd" and "template" in element.attrib:
+                    host_meta_cache[instance] = element.attrib["template"]
+                    break
+        # If no WebFinger URL is found by now, use the default.
+        if instance not in host_meta_cache:
+            # The last "{uri}" is intentionally not an f-string, it is needed verbatim.
+            host_meta_cache[instance] = f"https://{instance}/.well-known/webfinger?resource=" + "{uri}"
     try:
         response = await client.get(
-            f"https://{instance}/.well-known/webfinger",
-            params={"resource": f"acct:{acct}"},
+            host_meta_cache[instance].replace('{uri}', 'acct:' + acct),
             follow_redirects=True,  # Required for some servers depending on their setup
             timeout=30,
         )
@@ -23,22 +47,21 @@ async def get_activitypub_id_from_webfinger(acct, instance, client: httpx.AsyncC
         return None
     if response.status_code != 200:
         # This hints at a badly misconfigured server or an account that has been deleted.
-        # Potentially try again after some delay?
         logger.info("%s Error: status code %s for WebFinger data", acct, response.status_code)
         return None
+    result = None
     try:
         result = response.json()
     except JSONDecodeError:
         logger.info("%s Error: decoding JSON", acct)
         return None
     try:
-        # Is this OK style-wise or too crammed?
         for link in result.get("links") or []:
             if link.get("type") == "application/activity+json":
                 return link["href"]
         logger.info("%s Error: No ActivityPub link found in WebFinger data %s", acct, result)
         return None
-    except:
+    except KeyError:
         logger.info("%s Error: Malformed WebFinger data %s", acct, result)
         return None
 
@@ -55,11 +78,13 @@ class Command(RichCommand):
             "instance_model"
         )
         async with httpx.AsyncClient() as client:
+            # We cache host-meta results per instance in a simple dict because they do not change per account.
+            host_meta_cache = {}
             async for account in accounts_without_fingerprint:
                 acct = account.get_username_at_instance()
                 if acct[0] == "@":
                     acct = acct[1:]
-                account.activitypub_id = await get_activitypub_id_from_webfinger(acct, account.instance, client)
+                account.activitypub_id = await get_activitypub_id_from_webfinger(acct, account.instance, client, host_meta_cache)
                 if account.activitypub_id:
                     await account.asave(update_fields=["activitypub_id"])
                     # logger.info("%s: ActivityPub ID set", acct)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "fedidevs"
 version = "2024"
 requires-python = "~=3.13.0"
 dependencies = [
+  "defusedxml",
   "django",
   "django-dramatiq",
   "django-environ",

--- a/uv.lock
+++ b/uv.lock
@@ -171,6 +171,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -419,6 +428,7 @@ name = "fedidevs"
 version = "2024"
 source = { virtual = "." }
 dependencies = [
+    { name = "defusedxml" },
     { name = "django" },
     { name = "django-cotton" },
     { name = "django-csp" },
@@ -464,6 +474,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "defusedxml" },
     { name = "django" },
     { name = "django-cotton", specifier = ">=0.9.27" },
     { name = "django-csp", specifier = ">4.0b0" },


### PR DESCRIPTION
This adds support for [RFC 6415](https://datatracker.ietf.org/doc/html/rfc6415) (“host-meta”) to the WebFinger lookup command. This is needed for a few ActivityPub servers in the wild and should resolve some missing ActivityPub account IDs.

The implementation introduces a naive dict-based cache for WebFinger URLs so the host-meta info only needs to be fetched once per instance within one invocation of the command. I don't believe this information is worth persisting.

As a side note, this PR also fixes an oversight in `crawlone.py` for compatibility with older Mastodon versions.

Please note that my dev environment is/was not set up to really test this properly. I hope it works in practice.