### PR TITLE
Add summary / alt text to starter pack splash image ActivityPub and rename starter pack test functions

### DIFF
--- a/starter_packs/tests.py
+++ b/starter_packs/tests.py
@@ -322,7 +322,7 @@ class TestShareStarterPack(TestCase):
         ("text/plain", "text/html"),
     )
     @unpack
-    def test_activitypub(self, accept_header, expected_content_type):
+    def test_api_formats(self, accept_header, expected_content_type):
         # Testing the content negotiation. See: https://www.w3.org/TR/activitypub/#retrieving-objects
         response = self.client.get(
             reverse("share_starter_pack", args=[self.starter_pack.slug]),
@@ -331,7 +331,7 @@ class TestShareStarterPack(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers["Content-Type"].split(";")[0], expected_content_type)
 
-    def test_activitypub_plain_json(self):
+    def test_api_plain_json(self):
         # Testing the plain JSON response
         url = reverse("share_starter_pack", args=[self.starter_pack.slug])
         response = self.client.get(
@@ -385,7 +385,7 @@ class TestShareStarterPack(TestCase):
             },
         )
 
-    def test_activitypub_response(self):
+    def test_api_activitypub(self):
         # Testing the ActivityPub response
         url = reverse("share_starter_pack", args=[self.starter_pack.slug])
         response = self.client.get(

--- a/starter_packs/tests.py
+++ b/starter_packs/tests.py
@@ -422,6 +422,7 @@ class TestShareStarterPack(TestCase):
                 "type": "Image",
                 "mediaType": "image/png",
                 "url": "http://testserver/static/og-starterpack.png",
+                "summary": "",
             },
             "generator": {
                 "type": "Application",

--- a/starter_packs/views.py
+++ b/starter_packs/views.py
@@ -503,6 +503,16 @@ def share_starter_pack(request, starter_pack_slug):
                 "type": "Image",
                 "mediaType": "image/png",
                 "url": request.build_absolute_uri("/static/og-starterpack.png"),
+                # In The ActivityPub ecosystem, the `summary` property is commonly used for image
+                # alt text (analogous to the HTML `alt` attribute). We want to emphasize for other
+                # implementers and consumers that this is possible here. However, we supply an empty
+                # string as our alt text because our starter pack splash images are presumed to be
+                # “either decorative or supplemental to the rest of the content, redundant with
+                # some other information in the document” (WHATWG HTML Living Standard on what it
+                # means when the alt attribute is the empty string). That is, people who do not see
+                # the image lose no information since the title and content of the starter pack are
+                # right here in the same document.
+                "summary": "",
             },
             "generator": {
                 "type": "Application",


### PR DESCRIPTION
A long title for two very small updates to the ActivityPub stuff, the first of which takes way more lines of text to explain than to implement and test:

It was bothering me that we had no facility to add alternative text to our splash image in the ActivityPub representation. The ecosystem generally uses the `summary` property to provide replacement text for media, and that's inherited from `Object`, so we can use it for the splash image without any trouble.

However, I have currently hard-coded the splash image alt text to be the empty string. This is because I believe our splash images will be “either decorative or supplemental to the rest of the content, redundant with some other information in the document” ([WHATWG HTML Living Standard](https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element:attr-img-alt-5) on what it means when the alt attribute is the empty string). That is, the splash image contains nothing that isn't already present in the surrounding document, and serves only an aesthetic purpose. Having an empty string as the alt text signifies this, and thus has a different meaning than not having the alt text present at all. If the splash image design becomes much richer than I am anticipating, we may need to revisit this.

Point being, by adding an empty alt text / summary, we let consumers know that the splash image is purely decorative, and nudge other future implementers of the schema to think about whether their splash images should perhaps have alternative text.

I have also explained this in a code comment and updated the corresponding test alongside the implementation itself.

Speaking of the tests, the other change in this pull request is that I renamed the API test functions. With respect, looking at them after the last refactoring, I felt like their names no longer reflected their purpose.

Assuming you don't have any philosophical disagreements, this should be straightforward to merge.