### PR TITLE
Refine starter pack language pickers

### DIFF
--- a/starter_packs/models.py
+++ b/starter_packs/models.py
@@ -104,6 +104,10 @@ PACK_LANGUAGES = [
 LANGUAGE_CHOICES = [(lang.code, lang.name) for lang in PACK_LANGUAGES]
 LANGUAGES_BY_CODE = {lang.code: lang for lang in PACK_LANGUAGES}
 
+# The most common languages, shown by default in the pack editor's picker; the rest
+# stay behind a "Show more" toggle (or a search) to keep the list short.
+COMMON_LANGUAGE_CODES = ["en", "es", "pt", "de", "fr"]
+
 
 class StarterPack(models.Model):
     title = models.TextField(max_length=255)

--- a/starter_packs/templates/create_starter_pack.html
+++ b/starter_packs/templates/create_starter_pack.html
@@ -51,7 +51,8 @@
                          class="flex flex-wrap gap-2 max-h-56 overflow-y-auto p-1">
                         {% for lang in pack_languages %}
                             <label data-lang-name="{{ lang.name|lower }}"
-                                   class="language-option inline-flex items-center gap-1.5 cursor-pointer rounded-lg border border-gray-300 bg-gray-50 px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white">
+                                   data-common="{% if lang.code in common_languages %}1{% else %}0{% endif %}"
+                                   class="language-option {% if lang.code not in common_languages %}language-extra{% if lang.code not in selected_languages %} hidden{% endif %}{% endif %} inline-flex items-center gap-1.5 cursor-pointer rounded-lg border border-gray-300 bg-gray-50 px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white">
                                 <input type="checkbox"
                                        name="languages"
                                        value="{{ lang.code }}"
@@ -61,6 +62,11 @@
                             </label>
                         {% endfor %}
                     </div>
+                    <button type="button"
+                            id="language-show-more"
+                            class="mt-2 text-sm font-medium text-primary-700 hover:underline dark:text-primary-400">
+                        {% trans "Show more languages" %}
+                    </button>
                     <p id="language-no-results"
                        class="hidden mt-2 text-sm text-gray-500 dark:text-gray-400">
                         {% trans "No languages match your filter." %}
@@ -95,18 +101,41 @@
             const input = document.getElementById("language-filter");
             const container = document.getElementById("language-options");
             const noResults = document.getElementById("language-no-results");
+            const showMore = document.getElementById("language-show-more");
             if (!input || !container) return;
             const options = Array.from(container.querySelectorAll(".language-option"));
-            input.addEventListener("input", function () {
-                const query = this.value.trim().toLowerCase();
+            // Extras stay hidden until the user clicks "Show more" or searches; a
+            // non-empty query always searches the full list.
+            let expanded = false;
+
+            function apply() {
+                const query = input.value.trim().toLowerCase();
                 let visible = 0;
                 options.forEach(function (option) {
-                    const match = query === "" || option.dataset.langName.includes(query);
-                    option.classList.toggle("hidden", !match);
-                    if (match) visible++;
+                    const isExtra = option.dataset.common !== "1";
+                    const checked = option.querySelector("input[type=checkbox]").checked;
+                    let show;
+                    if (query !== "") {
+                        show = option.dataset.langName.includes(query);
+                    } else {
+                        show = !isExtra || expanded || checked;
+                    }
+                    option.classList.toggle("hidden", !show);
+                    if (show) visible++;
                 });
                 if (noResults) noResults.classList.toggle("hidden", visible !== 0);
-            });
+                // The toggle only makes sense in the collapsed, unfiltered state.
+                if (showMore) showMore.classList.toggle("hidden", expanded || query !== "");
+            }
+
+            input.addEventListener("input", apply);
+            if (showMore) {
+                showMore.addEventListener("click", function () {
+                    expanded = true;
+                    apply();
+                });
+            }
+            apply();
         })();
     </script>
 {% endblock content %}

--- a/starter_packs/tests.py
+++ b/starter_packs/tests.py
@@ -54,6 +54,16 @@ class TestStarterPacks(TestCase):
         self.assertContains(response, french_pack.title)
         self.assertNotContains(response, german_pack.title)
 
+    def test_language_filter_only_lists_used_languages(self):
+        baker.make("starter_packs.StarterPack", languages=["fr"], published_at=timezone.now())
+        response = self.client.get(reverse("starter_packs"))
+        self.assertEqual(response.status_code, 200)
+        # French is used by a published pack and appears as a filter option; German
+        # is not used, so it has no option. (The site locale switcher also has
+        # value="de" buttons, so we match the <option> specifically.)
+        self.assertContains(response, '<option value="fr"')
+        self.assertNotContains(response, '<option value="de"')
+
     def test_index_page_unknown_language_ignored(self):
         pack = baker.make(
             "starter_packs.StarterPack", title="Francophones", languages=["fr"], published_at=timezone.now()
@@ -82,6 +92,10 @@ class TestCreateStarterPack(TestCase):
         # the expanded list.
         self.assertContains(response, 'id="language-filter"')
         self.assertContains(response, "🇰🇪 Swahili")
+        # Uncommon languages are collapsed behind "Show more" by default (rendered
+        # as hidden extras, so no expanded extra chip is present).
+        self.assertContains(response, "Show more languages")
+        self.assertNotContains(response, "language-extra inline-flex")
 
     def test_create_starter_pack(self):
         self.client.force_login(self.user)
@@ -197,6 +211,15 @@ class TestEditStarterPack(TestCase):
         self.assertEqual(self.starter_pack.title, "New title")
         self.assertEqual(self.starter_pack.description, "New description")
         self.assertRedirects(response, reverse("edit_accounts_starter_pack", args=[self.starter_pack.slug]))
+
+    def test_edit_shows_selected_uncommon_language_expanded(self):
+        # Japanese is not a common language, but a pack tagged with it must show it
+        # by default (as a visible extra, not hidden behind "Show more").
+        self.starter_pack.languages = ["ja"]
+        self.starter_pack.save(update_fields=["languages"])
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("edit_starter_pack", args=[self.starter_pack.slug]))
+        self.assertContains(response, "language-extra inline-flex")
 
     def test_edit_starter_pack_languages(self):
         self.client.force_login(self.user)

--- a/starter_packs/views.py
+++ b/starter_packs/views.py
@@ -28,6 +28,7 @@ from accounts.management.commands.crawlone import crawlone
 from accounts.models import Account, Instance
 from mastodon_auth.models import AccountAccess, AccountFollowing
 from starter_packs.models import (
+    COMMON_LANGUAGE_CODES,
     LANGUAGE_CHOICES,
     MAX_LANGUAGES,
     MAX_OWNERS,
@@ -148,6 +149,15 @@ def starter_packs(request):
     else:
         language = ""
 
+    # Only offer languages in the filter that at least one published pack actually
+    # uses (plus the current selection, so an active filter stays visible).
+    used_language_codes = {language} if language else set()
+    for pack_languages in StarterPack.objects.filter(published_at__isnull=False, deleted_at__isnull=True).values_list(
+        "languages", flat=True
+    ):
+        used_language_codes.update(pack_languages)
+    filter_languages = [lang for lang in PACK_LANGUAGES if lang.code in used_language_codes]
+
     paginator = Paginator(starter_packs, 30)
     page_number = request.GET.get("page")
     page_obj = paginator.get_page(page_number)
@@ -183,7 +193,7 @@ def starter_packs(request):
             "starter_packs": page_obj,
             "pending_invitations": pending_invitations,
             "containing_username": request.GET.get("username", ""),
-            "pack_languages": PACK_LANGUAGES,
+            "pack_languages": filter_languages,
             "selected_language": language,
         },
     )
@@ -384,6 +394,7 @@ def edit_starter_pack(request, starter_pack_slug):
             "page_subheader": "",
             "form": form,
             "pack_languages": PACK_LANGUAGES,
+            "common_languages": COMMON_LANGUAGE_CODES,
             "selected_languages": form["languages"].value() or [],
             "max_languages": MAX_LANGUAGES,
             "starter_pack": starter_pack,
@@ -565,6 +576,7 @@ def create_starter_pack(request):
             "page_subheader": "",
             "form": form,
             "pack_languages": PACK_LANGUAGES,
+            "common_languages": COMMON_LANGUAGE_CODES,
             "selected_languages": form["languages"].value() or [],
             "max_languages": MAX_LANGUAGES,
         },


### PR DESCRIPTION
Follow-up to #246/#247.

- **Directory filter** now lists only languages that at least one *published* pack actually uses (plus the currently selected language, so an active filter stays visible). No more empty-result options.
- **Create/edit picker** shows the five most common languages by default (English, Spanish, Portuguese, German, French) with a **"Show more languages"** toggle for the rest. Uncommon languages that are already selected on a pack stay visible; the search box still matches the full list even while collapsed.

Full suite green (220 passed), ruff + djlint clean, no missing migrations.